### PR TITLE
Bugfix for the help dialogue

### DIFF
--- a/vide.sh
+++ b/vide.sh
@@ -24,8 +24,8 @@ help() {
                   [-${BD}ka${RST}]                      enable ${FBU}ka${RST}tana crwal
                   [-${BD}by${RST}]                      enable ${FBU}by${RST}pass (40X) scans
                   [-${BD}p${RST} <path to webservers>]  ${FBU}p${RST}ass list of servers to process {<PROTO>://<IP>[:<PORT>]}
-                  [-${BD}c${RST} <path to config>]      ${FBU}c${RST}onfig file to pass (default: vide.cfg)\n"
-                  [--${BD}check${RST}]                  verify configuration file (default: config.sh)
+                  [-${BD}c${RST} <path to config>]      ${FBU}c${RST}onfig file to pass (default: vide.cfg)\n
+                  [--${BD}check${RST}]                  verify configuration file (default: config.sh)\n"
 
     exit 2
 }


### PR DESCRIPTION
Nice tool, I like it. There's a small syntax error in the formatting section of the help dialogue, however, which slightly hampers my enjoyment.

This commit would fix that error and also add an explicit newline at the end of the help dialogue (in order to prevent some unforeseen terminal f*** ups).